### PR TITLE
Allow script modification before execution

### DIFF
--- a/Database.cs
+++ b/Database.cs
@@ -14,28 +14,39 @@ namespace Archon.Data
 	{
 		static readonly Regex goEx = new Regex(@"^\s*go\s*$", RegexOptions.Compiled | RegexOptions.Multiline | RegexOptions.IgnoreCase);
 
+		readonly string connectionString;
 		readonly Assembly ass;
 		readonly string[] createSql;
 		readonly string[] clearSql;
 
-		public Database(Type scriptType)
+		public string ConnectionString => connectionString;
+
+		public Database(string connectionString, Type scriptType)
 		{
+			if (String.IsNullOrWhiteSpace(connectionString))
+				throw new ArgumentNullException(nameof(connectionString));
+
 			if (scriptType == null)
 				throw new ArgumentNullException(nameof(scriptType));
 
+			this.connectionString = connectionString;
 			ass = scriptType.GetTypeInfo().Assembly;
 			createSql = ParseScript(ReadScript(scriptType.Namespace, "create"));
 			clearSql = ParseScript(ReadScript(scriptType.Namespace, "clear"));
 		}
 
-		public Database(Assembly scriptAss, string scriptNamespace)
+		public Database(string connectionString, Assembly scriptAss, string scriptNamespace)
 		{
+			if (String.IsNullOrWhiteSpace(connectionString))
+				throw new ArgumentNullException(nameof(connectionString));
+
 			if (scriptAss == null)
 				throw new ArgumentNullException(nameof(scriptAss));
 
 			if (String.IsNullOrWhiteSpace(scriptNamespace))
 				throw new ArgumentNullException(nameof(scriptNamespace));
 
+			this.connectionString = connectionString;
 			ass = scriptAss;
 			createSql = ParseScript(ReadScript(scriptNamespace, "create"));
 			clearSql = ParseScript(ReadScript(scriptNamespace, "clear"));
@@ -65,7 +76,7 @@ namespace Archon.Data
 			return goEx.Split(script).Where(c => !goEx.IsMatch(c) && !String.IsNullOrWhiteSpace(c)).ToArray();
 		}
 
-		public bool Exists(string connectionString)
+		public bool Exists()
 		{
 			var builder = new SqlConnectionStringBuilder(connectionString);
 
@@ -81,7 +92,7 @@ namespace Archon.Data
 			return count > 0;
 		}
 
-		public void Rebuild(string connectionString)
+		public void Rebuild()
 		{
 			var builder = new SqlConnectionStringBuilder(connectionString);
 
@@ -99,10 +110,10 @@ namespace Archon.Data
 				));
 			}
 
-			Build(connectionString);
+			Build();
 		}
 
-		public void Build(string connectionString)
+		public void Build()
 		{
 			var builder = new SqlConnectionStringBuilder(connectionString);
 
@@ -128,7 +139,7 @@ namespace Archon.Data
 				conn.Execute(statement);
 		}
 
-		public void Clear(string connectionString)
+		public void Clear()
 		{
 			using (var conn = new SqlConnection(connectionString))
 			{

--- a/README.md
+++ b/README.md
@@ -15,13 +15,15 @@ dotnet add package Archon.Data
 You should have a `create.sql` & a `clear.sql` as embedded resources in your class library. The `create.sql` script should only create tables & schemas and whatnot. It shouldn't try to create the database. The `clear.sql` script should simply clear the tables. Don't drop or create tables in the `clear.sql` script.
 
 ```cs
-var db = new Database(typeof(MyType)); //where MyType is in the same namespace as your create.sql & clear.sql
+string connectionString = "server=.\\sqlexpress;database=mydb;integrated security=true;";
+var db = new Database(connectionString, typeof(MyType)); //where MyType is in the same namespace as your create.sql & clear.sql
 ```
 
 or
 
 ```cs
-var db = new Database(typeof(MyType).Assembly, "MyAssembly.Weird.Namespace.Folder1"); //specify what namespace the embedded create & clear sql scripts are in
+string connectionString = "server=.\\sqlexpress;database=mydb;integrated security=true;";
+var db = new Database(connectionString, typeof(MyType).Assembly, "MyAssembly.Weird.Namespace.Folder1"); //specify what namespace the embedded create & clear sql scripts are in
 ```
 
 ### Check if Database Exists
@@ -29,7 +31,7 @@ var db = new Database(typeof(MyType).Assembly, "MyAssembly.Weird.Namespace.Folde
 To check if a database exists:
 
 ```cs
-bool exists = db.Exists("server=.\\sqlexpress;database=mydb;integrated security=true;");
+bool exists = db.Exists();
 ```
 
 It will return `true` or `false` depending on if the database in the connection string exists or not.
@@ -39,7 +41,7 @@ It will return `true` or `false` depending on if the database in the connection 
 To build a new database using the `create.sql` script:
 
 ```cs
-db.Build("server=.\\sqlexpress;database=mydb;integrated security=true;");
+db.Build();
 ```
 
 This will create the database if it doesn't already exist and then run the `create.sql` script against it.
@@ -49,7 +51,7 @@ This will create the database if it doesn't already exist and then run the `crea
 To drop an existing database and recreate it using the `create.sql` script:
 
 ```cs
-db.Rebuild("server=.\\sqlexpress;database=mydb;integrated security=true;");
+db.Rebuild();
 ```
 
 This will drop the database if it exists and then recreate it running the `create.sql` script against it.
@@ -69,7 +71,7 @@ The connection will be opened if it is not already opened and then the `create.s
 To run the `clear.sql` against an existing database:
 
 ```cs
-db.Clear(myConn); //you can also pass a connection string here
+db.Clear(myConn); //you can also not pass a connection object to run against the original connection string
 ```
 
 This will open the connection if it is not already open (or create a connection from the connection string) and then run the `clear.sql` script. This will fail if the database does not exist.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,13 @@ To build a new database using the `create.sql` script:
 db.Build();
 ```
 
-This will create the database if it doesn't already exist and then run the `create.sql` script against it.
+This will create the database if it doesn't already exist and then run the `create.sql` script against it. You can also use the overload which takes a `modifyScript` delegate to modify each script before it is executed (e.g. to replace tokens based on environment):
+
+```cs
+db.Build(sql => sql.Replace("{schema_name}", Thread.CurrentThread.Name));
+```
+
+Note: if the delegate returns `null` for a particular script, that script will not be run.
 
 ### Rebuild a Database
 
@@ -54,7 +60,7 @@ To drop an existing database and recreate it using the `create.sql` script:
 db.Rebuild();
 ```
 
-This will drop the database if it exists and then recreate it running the `create.sql` script against it.
+This will drop the database if it exists and then recreate it running the `create.sql` script against it. This method also has an overload which accepts a a `modifyScript` delegate.
 
 ### Build the Schema Only
 
@@ -64,7 +70,7 @@ To only run the `create.sql` script with an existing `IDbConnection`:
 db.BuildSchema(myConn);
 ```
 
-The connection will be opened if it is not already opened and then the `create.sql` script will be run.
+The connection will be opened if it is not already opened and then the `create.sql` script will be run. This method also has an overload which accepts a a `modifyScript` delegate.
 
 ### Clear the Database
 
@@ -74,7 +80,7 @@ To run the `clear.sql` against an existing database:
 db.Clear(myConn); //you can also not pass a connection object to run against the original connection string
 ```
 
-This will open the connection if it is not already open (or create a connection from the connection string) and then run the `clear.sql` script. This will fail if the database does not exist.
+This will open the connection if it is not already open (or create a connection from the connection string) and then run the `clear.sql` script. This will fail if the database does not exist. This method also has an overload which accepts a a `modifyScript` delegate.
 
 ### `DataContext`
 


### PR DESCRIPTION
Add feature to `Database` to allow modification of creation/clear scripts before they are executed against the database. This is useful to replace tokens in scripts based on a current context.

Need this for [CS-15572](https://jira.archoninfosys.com:8181/browse/CS-15572)

Also updating `Database` to take connection string in ctor - since it was very annoying that it didn't do that previously.
