### PR TITLE
Azure compatibility

### DIFF
--- a/Database.cs
+++ b/Database.cs
@@ -90,7 +90,7 @@ namespace Archon.Data
 
 			using (var conn = new SqlConnection(builder.ToString()))
 			{
-				return await conn.QuerySingleOrDefaultAsync<int>("select count(*) from sysdatabases where [Name] = @database", new { database }, commandTimeout: commandTimeout) > 0;
+				return await conn.QuerySingleOrDefaultAsync<int>("SELECT COUNT(*) FROM sys.sysdatabases WHERE [Name] = @database", new { database }, commandTimeout: commandTimeout) > 0;
 			}
 		}
 
@@ -106,11 +106,11 @@ namespace Archon.Data
 			using (var conn = new SqlConnection(builder.ToString()))
 			{
 				await conn.ExecuteAsync($@"
-					if db_id('{database}') is not null
-					begin
-						alter database [{database}] set single_user with rollback immediate;
-						drop database [{database}];
-					end",
+					IF EXISTS (SELECT 1 FROM sys.sysdatabases WHERE name = '{database}')
+					BEGIN
+						ALTER DATABASE [{database}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
+						DROP DATABASE [{database}];
+					END",
 					commandTimeout: commandTimeout
 				);
 			}
@@ -129,7 +129,7 @@ namespace Archon.Data
 
 			using (var conn = new SqlConnection(builder.ToString()))
 			{
-				await conn.ExecuteAsync($"if db_id('{database}') is null create database [{database}]", commandTimeout: commandTimeout);
+				await conn.ExecuteAsync($"IF EXISTS (SELECT 1 FROM sys.sysdatabases WHERE name = '{database}') CREATE DATABASE [{database}]", commandTimeout: commandTimeout);
 			}
 
 			using (var conn = new SqlConnection(connectionString))

--- a/Database.cs
+++ b/Database.cs
@@ -130,7 +130,7 @@ namespace Archon.Data
 
 			using (var conn = new SqlConnection(builder.ToString()))
 			{
-				await conn.ExecuteAsync($"IF EXISTS (SELECT 1 FROM sys.sysdatabases WHERE name = '{database}') CREATE DATABASE [{database}]", commandTimeout: commandTimeout);
+				await conn.ExecuteAsync($"IF NOT EXISTS (SELECT 1 FROM sys.sysdatabases WHERE name = '{database}') CREATE DATABASE [{database}]", commandTimeout: commandTimeout);
 			}
 
 			using (var conn = new SqlConnection(connectionString))

--- a/Database.cs
+++ b/Database.cs
@@ -90,7 +90,8 @@ namespace Archon.Data
 
 			using (var conn = new SqlConnection(builder.ToString()))
 			{
-				return await conn.QuerySingleOrDefaultAsync<int>("SELECT COUNT(*) FROM sys.sysdatabases WHERE [Name] = @database", new { database }, commandTimeout: commandTimeout) > 0;
+				return await conn.ExecuteScalarAsync<bool>("SELECT TOP 1 1 FROM sys.sysdatabases WHERE [Name] = @database", new { database },
+					commandTimeout: commandTimeout);
 			}
 		}
 


### PR DESCRIPTION
I ran into a handful of other issues preventing the unit tests from utilising Azure databases:

* `CREATE DATABASE` against Azure can take a while — so long, in fact, that the default command timeout of 10 seconds isn't long enough.
* `DB_ID()` function in Azure [cannot check for the existence of other databases than the one currently connected to](https://docs.microsoft.com/en-us/sql/t-sql/functions/db-id-transact-sql?view=sql-server-2017), so it has been replaced with a query against `sys.sysdatabases`.
* The `ExistsAsync()` logic has been streamlined to return an optional scalar value which the `SqlClient` interprets as a `bool`, removing the need to compare the count against zero.

```csharp
> db.ExecuteScalar<bool>("SELECT TOP 1 1") // returns 1 row containing (1)
true
> db.ExecuteScalar<bool>("SELECT TOP 0 1") // returns 0 rows 
false
> db.ExecuteScalar<bool>("SELECT TOP 1 NULL") // returns 1 row containing (NULL)
false
```